### PR TITLE
add tests for names controller and name model

### DIFF
--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -20,5 +20,6 @@ class NamesController < ApplicationController
     names = names.where(sex: params[:sex]) if params[:sex]
     names = names.where(year: params[:year].to_i) if params[:year]
     names = names.where("popularity <= ?", params[:popularity]) if params[:popularity]
+    names
   end
 end

--- a/test/controllers/names_controller_test.rb
+++ b/test/controllers/names_controller_test.rb
@@ -1,7 +1,48 @@
 require "test_helper"
 
 class NamesControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  test "should get index" do
+    get names_url
+    assert_response :success
+    assert_equal "application/json; charset=utf-8", response.content_type
+  end
+
+  test "get female names" do
+    get names_url, params: { sex: "F" }
+    assert_response :success
+    assert_equal "application/json; charset=utf-8", response.content_type
+    assert_includes response.body, "Olivia"
+    assert_includes response.body, "Ariadne"
+    refute_includes response.body, "Liam"
+    refute_includes response.body, "Jermaine"
+  end
+
+
+  test "get male names" do
+    get names_url, params: { sex: "M" }
+    assert_response :success
+    assert_equal "application/json; charset=utf-8", response.content_type
+    assert_includes response.body, "Liam"
+    assert_includes response.body, "Jermaine"
+    refute_includes response.body, "Olivia"
+    refute_includes response.body, "Ariadne"
+  end
+
+  test "get female names from 2019" do
+    get names_url, params: { sex: "F", year: "2019"}
+    assert_response :success
+    assert_equal "application/json; charset=utf-8", response.content_type
+    assert_includes response.body, "2019"
+    refute_includes response.body, "2018"
+  end
+
+  test "get top 10 female names from 2019" do
+    get names_url, params: { sex: "F", year: "2019", popularity: "10"}
+    assert_response :success
+    assert_equal "application/json; charset=utf-8", response.content_type
+    assert_includes response.body, "2019"
+    refute_includes response.body, "2018"
+    assert_includes response.body, "Olivia"
+    refute_includes response.body, "Ariadne"
+  end
 end

--- a/test/fixtures/names.yml
+++ b/test/fixtures/names.yml
@@ -3,9 +3,39 @@
 # This model initially had no columns defined. If you add columns to the
 # model remove the '{}' from the fixture names and add the columns immediately
 # below each fixture, per the syntax in the comments below
-#
-one: {}
-# column: value
-#
-two: {}
-# column: value
+
+olivia:
+  id: 1
+  name: Olivia
+  sex: F
+  count: 18451
+  popularity: 1
+  year: 2019
+  country: U.S.A.
+
+ariadne:
+  id: 999
+  name: Ariadne
+  sex: F
+  count: 256
+  popularity: 999
+  year: 2019
+  country: U.S.A.
+
+liam:
+  id: 1001,
+  name: Liam
+  sex: M
+  count: 20502
+  popularity: 1
+  year: 2019
+  country: U.S.A.
+
+jermaine:
+  id: 1994
+  name: Jermaine
+  sex: M
+  count: 210
+  popularity: 994
+  year: 2019
+  country: U.S.A.

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -1,7 +1,8 @@
 require "test_helper"
 
 class NameTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "should not save name without without required fields" do
+    name = Name.new
+    assert_not name.save
+  end
 end


### PR DESCRIPTION
There was an issue with how results were parsed, depending on exactly what parameters are requested from the frontend. That issue is fixed here and the api can now accept requests containing any combination of filters for sex, year, and popularity.

I've also added tests for the Names controller and the Name model. 

The tests themselves could be improved, and some of the logic currently in the controller should likely be moved to the model, but I wanted to get this working correctly and get some initial tests written. I will submit a future PR to improve these items.