### PR TITLE
Add basic user authentication

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,8 @@ gem 'puma', '~> 5.0'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+gem 'bcrypt', '~> 3.1.7'
+gem 'jwt', '~> 2.2.2'
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,7 @@ GEM
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
     ansi (1.5.0)
+    bcrypt (3.1.16)
     bootsnap (1.7.2)
       msgpack (~> 1.0)
     builder (3.2.4)
@@ -88,6 +89,7 @@ GEM
       minitest (>= 3.0)
     i18n (1.8.8)
       concurrent-ruby (~> 1.0)
+    jwt (2.2.2)
     listen (3.4.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -182,10 +184,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.4)
   byebug
   guard (= 2.16.2)
   guard-minitest (= 2.4.6)
+  jwt (~> 2.2.2)
   listen (~> 3.3)
   minitest-reporters (= 1.3.8)
   pg (~> 1.1)

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -5,7 +5,7 @@ class AuthController < ApplicationController
       token = JWT.encode({ user_id: user.id }, Rails.application.secret_key_base, 'HS256')
       render json: { user: user, token: token }
     else
-      render json: {}, status: 401
+      render json: {}, status: :unauthorized
     end
   end
 
@@ -18,10 +18,10 @@ class AuthController < ApplicationController
         user = User.find(user_id)
         render json: user
       rescue
-        render json: {}, status: 401
+        render json: {}, status: :unauthorized
       end
     else
-      render json: {}, status: 401
+      render json: {}, status: :unauthorized
     end
   end
 

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -1,0 +1,33 @@
+class AuthController < ApplicationController
+  def login
+    user = User.find_by(username: login_params[:username])
+    if user && user.authenticate(login_params[:password])
+      token = JWT.encode({ user_id: user.id }, Rails.application.secret_key_base, 'HS256')
+      render json: { user: user, token: token }
+    else
+      render json: {}, status: 401
+    end
+  end
+
+  def persist
+    if request.headers['Authorization']
+      encoded_token = request.headers['Authorization']
+      begin
+        token = JWT.decode(encoded_token, Rails.application.secret_key_base, true, algorithm: 'HS256')
+        user_id = token[0]['user_id']
+        user = User.find(user_id)
+        render json: user
+      rescue
+        render json: {}, status: 401
+      end
+    else
+      render json: {}, status: 401
+    end
+  end
+
+  private
+
+  def login_params
+    params.permit(:username, :password)
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,34 @@
+class UsersController < ApplicationController
+  def show
+    user = User.find(params[:id])
+    render json: user
+  end
+
+  def create
+    user = User.create(user_params)
+    if user.valid?
+      user = user
+      token = JWT.encode({ user_id: user.id }, Rails.application.secret_key_base, 'HS256')
+      render json: { user: user, token: token }
+    else
+      render json: { errors: user.errors.full_messages }
+    end
+  end
+
+  def update
+    user = User.find(params[:id])
+    user.update(user_params)
+    render json: user
+  end
+
+  def destroy
+    user = User.find(params[:id])
+    user.destroy
+  end
+
+  private
+
+  def user_params
+    params.permit(:username, :password)
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,7 +7,6 @@ class UsersController < ApplicationController
   def create
     user = User.create(user_params)
     if user.valid?
-      user = user
       token = JWT.encode({ user_id: user.id }, Rails.application.secret_key_base, 'HS256')
       render json: { user: user, token: token }
     else
@@ -29,6 +28,6 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.permit(:username, :password)
+    params.permit(:username, :password, :email)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,13 @@
 class User < ApplicationRecord
+  before_save { self.email = self.email.downcase }
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
+
   has_secure_password
   validates :username, uniqueness: { case_sensitive: false }, presence: true, length: { maximum: 25 }
   validates :password, presence: true, length: { minimum: 8 }
+  validates :email, presence: true, length: { maximum: 255 },
+            format: { with: VALID_EMAIL_REGEX },
+            uniqueness: true
 
   def as_json(options = {})
     # options hash accepts four keys for customization :only, :methods, :include, :except

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,15 @@
+class User < ApplicationRecord
+  has_secure_password
+  validates :username, uniqueness: { case_sensitive: false }, presence: true, length: { maximum: 25 }
+  validates :password, presence: true, length: { minimum: 8 }
+
+  def as_json(options = {})
+    # options hash accepts four keys for customization :only, :methods, :include, :except
+    if options.key?(:only) || options.key?(:methods) ||
+       options.key?(:include) || options.key?(:except)
+      super(options)
+    else
+      super(only: [:username, :created_at])
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  resources :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   resources :names, only: :index
+  post '/login', to: 'auth#login'
+  get '/auth',   to: 'auth#persist'
 end

--- a/db/migrate/20210310190758_create_users.rb
+++ b/db/migrate/20210310190758_create_users.rb
@@ -1,0 +1,10 @@
+class CreateUsers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :users do |t|
+      t.string :username
+      t.string :password_digest
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210326014601_add_email_to_users.rb
+++ b/db/migrate/20210326014601_add_email_to_users.rb
@@ -1,0 +1,5 @@
+class AddEmailToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_10_190758) do
+ActiveRecord::Schema.define(version: 2021_03_26_014601) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 2021_03_10_190758) do
     t.string "password_digest"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "email"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_04_032514) do
+ActiveRecord::Schema.define(version: 2021_03_10_190758) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,13 @@ ActiveRecord::Schema.define(version: 2021_03_04_032514) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["name", "sex", "popularity", "year"], name: "index_names_on_name_and_sex_and_popularity_and_year"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "username"
+    t.string "password_digest"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
 end

--- a/test/controllers/auth_controller_test.rb
+++ b/test/controllers/auth_controller_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class AuthControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = User.first
+  end
+
+  test "should login valid user" do
+    post '/login', params: { username: @user.username,
+                             password: "secretpw" }
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal @user.username, body["user"]["username"]
+    assert_not_empty body["token"]
+    assert_nil body["user"]["password_digest"]
+  end
+
+  test "should return 401 when user tries to login with wrong pw" do
+    post '/login', params: { username: @user.username,
+                             password: "secretpw2" }
+    body = JSON.parse(response.body)
+    assert_response(401)
+    assert_empty body
+  end
+
+  test "should return 401 when non-existent user tries to login" do
+    post '/login', params: { username: "MadeUpUser",
+                             password: "secretpw" }
+    body = JSON.parse(response.body)
+    assert_response(401)
+    assert_empty body
+  end
+
+  test "should authorize user when user has token" do
+    token = JWT.encode({ user_id: @user.id }, Rails.application.secret_key_base, 'HS256')
+    get '/auth', headers: { "Authorization": token }
+    body = JSON.parse(response.body)
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal @user.username, body["username"]
+    assert_nil body["password_digest"]
+  end
+
+  test "should return 401 when user doesn't have token" do
+    get '/auth'
+    body = JSON.parse(response.body)
+    assert_response(401)
+    assert_empty body
+  end
+
+  test "should return 401 when user has invalid token" do
+    token = JWT.encode({ user_id: @user.id }, "madeupsecret", 'HS256')
+    get '/auth', headers: { "Authorization": token }
+    body = JSON.parse(response.body)
+    assert_response(401)
+    assert_empty body
+  end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -15,7 +15,8 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
   test "should create new user" do
     username = "TestUser3"
-    post '/users', params: { username: username, password: "secretpw"}
+    email = "testuser3@example.com"
+    post '/users', params: { username: username, password: "secretpw", email: email }
     assert_response :success
     body = JSON.parse(response.body)
     assert_equal username, body["user"]["username"]
@@ -40,7 +41,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should delete user" do
-    user_id = @user.id
     assert_difference("User.count", -1) do
       delete user_path(@user)
     end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = User.first
+  end
+
+  test "should get show" do
+    get user_path(@user)
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal @user.username, body["username"]
+    assert_nil body["password_digest"]
+  end
+
+  test "should create new user" do
+    username = "TestUser3"
+    post '/users', params: { username: username, password: "secretpw"}
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal username, body["user"]["username"]
+    assert_nil body["user"]["password_digest"]
+    assert_not_empty body["token"]
+  end
+
+  test "should recieve errors when user fails to be created" do
+    post '/users'
+    body = JSON.parse(response.body)
+    assert_response :success
+    assert_not_empty body["errors"]
+  end
+
+  test "should update user's username" do
+    new_username = "UpdatedUser1"
+    patch user_path(@user), params: { username: new_username }
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal new_username, body["username"]
+    assert_nil body["password_digest"]
+  end
+
+  test "should delete user" do
+    user_id = @user.id
+    assert_difference("User.count", -1) do
+      delete user_path(@user)
+    end
+  end
+end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -3,7 +3,9 @@
 one:
   username: 'User1'
   password_digest: <%= BCrypt::Password.create('secretpw') %>
+  email: 'User1@example.com'
 
 two:
   username: 'User2'
   password_digest: <%= BCrypt::Password.create('secretpw') %>
+  email: 'User2@example.com'

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  username: 'User1'
+  password_digest: <%= BCrypt::Password.create('secretpw') %>
+
+two:
+  username: 'User2'
+  password_digest: <%= BCrypt::Password.create('secretpw') %>

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  def setup
+    @user = User.new(username: "TestUser1", password: "secretpw")
+  end
+
+  test "user should be valid" do
+    assert @user.valid?
+  end
+
+  test "empty username should be invalid" do
+    @user.username = ""
+    assert_not @user.valid?
+  end
+
+  test "username should not exceed 25 characters" do
+    @user.username = "c" * 26
+    assert_not @user.valid?
+  end
+
+  test "username must be unique" do
+    duplicate_user = @user.dup
+    @user.save
+    assert_not duplicate_user.valid?
+  end
+
+  test "username must be unique on case-insensitive basis" do
+    duplicate_user = @user.dup
+    @user.save
+    duplicate_user.username = duplicate_user.username.downcase
+    assert_not duplicate_user.valid?
+  end
+
+  test "user without password should be invalid" do
+    test_user = User.new(username: "TestUser5")
+    assert_not test_user.valid?
+  end
+
+  test "password must be at least 8 characters" do
+    test_user = User.new(username: "TestUser5", password: "secret")
+    assert_not test_user.valid?
+  end
+
+  test "password must not be blank" do
+    test_user = User.new(username: "TestUser5")
+    test_user.password = "        "
+    assert_not test_user.valid?
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
   def setup
-    @user = User.new(username: "TestUser1", password: "secretpw")
+    @user = User.new(username: "TestUser1", password: "secretpw", email:"TestUser1@example.com")
   end
 
   test "user should be valid" do


### PR DESCRIPTION
# Authentication

The API now supports basic user authentication and this PR reflects the following changes:

- add BCrypt and JWT as dependencies
- add routes for users resource, login and auth
- update schema to add Users table
- add user model
- create user fixtures for tests
- add tests for new user model
- add Auth controller
- add tests for new Auth controller
- add new Users controller
- add tests for new Users controller

## Tests

Tests for the new User model, User controller and Auth controller are included in this PR